### PR TITLE
Fix missing function :crypto.hmac/3 error in Erlang 24

### DIFF
--- a/lib/microsoft/azure/storage/crypto.ex
+++ b/lib/microsoft/azure/storage/crypto.ex
@@ -1,0 +1,7 @@
+defmodule Microsoft.Azure.Storage.Crypto do
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    def hmac(digest, key, payload), do: :crypto.mac(:hmac, digest, key, payload)
+  else
+    def hmac(digest, key, payload), do: :crypto.hmac(digest, key, payload)
+  end
+end

--- a/lib/microsoft/azure/storage/request_builder.ex
+++ b/lib/microsoft/azure/storage/request_builder.ex
@@ -195,7 +195,7 @@ defmodule Microsoft.Azure.Storage.RequestBuilder do
       |> Enum.join("\n")
 
     signature =
-      :crypto.hmac(:sha256, storage_context.account_key |> Base.decode64!(), stringToSign)
+      :crypto.mac(:hmac, :sha256, storage_context.account_key |> Base.decode64!(), stringToSign)
       |> Base.encode64()
 
     data

--- a/lib/microsoft/azure/storage/request_builder.ex
+++ b/lib/microsoft/azure/storage/request_builder.ex
@@ -195,7 +195,7 @@ defmodule Microsoft.Azure.Storage.RequestBuilder do
       |> Enum.join("\n")
 
     signature =
-      :crypto.mac(:hmac, :sha256, storage_context.account_key |> Base.decode64!(), stringToSign)
+      Storage.Crypto.hmac(:sha256, account_key |> Base.decode64!(), stringToSign)
       |> Base.encode64()
 
     data

--- a/lib/microsoft/azure/storage/shared_access_signature.ex
+++ b/lib/microsoft/azure/storage/shared_access_signature.ex
@@ -170,7 +170,7 @@ defmodule Microsoft.Azure.Storage.SharedAccessSignature do
     stringToSign = string_to_sign(values, account_name, target_scope)
 
     signature =
-      :crypto.hmac(:sha256, account_key |> Base.decode64!(), stringToSign)
+      :crypto.mac(:hmac, :sha256, account_key |> Base.decode64!(), stringToSign)
       |> Base.encode64()
 
     values

--- a/lib/microsoft/azure/storage/shared_access_signature.ex
+++ b/lib/microsoft/azure/storage/shared_access_signature.ex
@@ -170,7 +170,7 @@ defmodule Microsoft.Azure.Storage.SharedAccessSignature do
     stringToSign = string_to_sign(values, account_name, target_scope)
 
     signature =
-      :crypto.mac(:hmac, :sha256, account_key |> Base.decode64!(), stringToSign)
+      Storage.Crypto.hmac(:sha256, account_key |> Base.decode64!(), stringToSign)
       |> Base.encode64()
 
     values

--- a/test/ex_microsoft_azure_storage_test.exs
+++ b/test/ex_microsoft_azure_storage_test.exs
@@ -8,7 +8,7 @@ defmodule ExMicrosoftAzureStorageTest do
   test "Tests HMAC SHA256" do
     # https://en.wikipedia.org/wiki/HMAC#Examples
     assert Base.encode16(
-             :crypto.hmac(:sha256, "key", "The quick brown fox jumps over the lazy dog"),
+             :crypto.mac(:hmac, :sha256, "key", "The quick brown fox jumps over the lazy dog"),
              case: :lower
            ) == "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
   end

--- a/test/ex_microsoft_azure_storage_test.exs
+++ b/test/ex_microsoft_azure_storage_test.exs
@@ -1,6 +1,7 @@
 defmodule ExMicrosoftAzureStorageTest do
   use ExUnit.Case
   # doctest ExMicrosoftAzureStorage
+  alias Microsoft.Azure.Storage
   alias Microsoft.Azure.Storage.ApiVersion
 
   import SweetXml
@@ -8,7 +9,7 @@ defmodule ExMicrosoftAzureStorageTest do
   test "Tests HMAC SHA256" do
     # https://en.wikipedia.org/wiki/HMAC#Examples
     assert Base.encode16(
-             :crypto.mac(:hmac, :sha256, "key", "The quick brown fox jumps over the lazy dog"),
+             Storage.Crypto.hmac(:sha256, "key", "The quick brown fox jumps over the lazy dog"),
              case: :lower
            ) == "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
   end


### PR DESCRIPTION
Erlang 22.1 introduces `:crypto.mac/4`, 23 deprecates `:crypto.hmac/3` and 24 removes it.

This PR adds support for both functions depending on which one exists.